### PR TITLE
Reduce live quote load and update vulnerable dependencies

### DIFF
--- a/backend/services/quote_cache.py
+++ b/backend/services/quote_cache.py
@@ -17,6 +17,7 @@ from typing import Any
 import yfinance as yf
 
 _LIVE_PRICE_TTL_SECONDS = 30.0
+_LIVE_PRICE_MISS_TTL_SECONDS = 300.0
 _INTRADAY_TTL_SECONDS = 60.0
 _FUNDAMENTALS_TTL_SECONDS = 3600.0
 
@@ -57,15 +58,17 @@ class _TTLCache:
 
 
 _live_price_cache = _TTLCache(_LIVE_PRICE_TTL_SECONDS)
+_live_price_miss_cache = _TTLCache(_LIVE_PRICE_MISS_TTL_SECONDS)
 intraday_cache = _TTLCache(_INTRADAY_TTL_SECONDS)
 fundamentals_cache = _TTLCache(_FUNDAMENTALS_TTL_SECONDS)
 
 
 def _fetch_one_live_price(ticker: str) -> float | None:
+    if _live_price_miss_cache.get(ticker) is not None:
+        return None
     cached = _live_price_cache.get(ticker)
     if cached is not None:
-        # Sentinel for "we tried, it failed" — re-cache as None to avoid hammering.
-        return None if cached == "__miss__" else cached  # type: ignore[return-value]
+        return cached  # type: ignore[return-value]
     try:
         info = yf.Ticker(ticker).fast_info
         # fast_info exposes last_price as an attribute or mapping key depending on version.
@@ -73,11 +76,11 @@ def _fetch_one_live_price(ticker: str) -> float | None:
         if price is None and hasattr(info, "get"):
             price = info.get("last_price") or info.get("lastPrice")
         if price is None:
-            _live_price_cache.set(ticker, "__miss__")
+            _live_price_miss_cache.set(ticker, True)
             return None
         value = float(price)
     except Exception:
-        _live_price_cache.set(ticker, "__miss__")
+        _live_price_miss_cache.set(ticker, True)
         return None
     _live_price_cache.set(ticker, value)
     return value

--- a/main.py
+++ b/main.py
@@ -228,10 +228,6 @@ def _read_latest_prices(tickers: list[str]) -> LivePrices:
     cleaned = [ticker.strip().upper() for ticker in tickers if ticker.strip()]
     if not cleaned:
         return LivePrices(prices={}, timestamp="")
-    try:
-        ensure_market_data(cleaned, source="live_prices")
-    except Exception as exc:  # pragma: no cover - network/provider dependent
-        logger.warning("Live price bootstrap sync failed: %s", exc)
     live = fetch_live_prices(cleaned)
     fallback = _read_db_closes([t for t, p in live.items() if p is None])
     prices: dict[str, float | None] = {

--- a/tests/test_quote_cache.py
+++ b/tests/test_quote_cache.py
@@ -1,0 +1,20 @@
+from backend.services import quote_cache
+
+
+def test_failed_live_quote_is_cached(monkeypatch):
+    calls = 0
+
+    class FakeTicker:
+        @property
+        def fast_info(self):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(quote_cache, "_live_price_cache", quote_cache._TTLCache(30))
+    monkeypatch.setattr(quote_cache, "_live_price_miss_cache", quote_cache._TTLCache(300))
+    monkeypatch.setattr(quote_cache.yf, "Ticker", lambda _: FakeTicker())
+
+    assert quote_cache._fetch_one_live_price("MISSING") is None
+    assert quote_cache._fetch_one_live_price("MISSING") is None
+    assert calls == 1

--- a/uv.lock
+++ b/uv.lock
@@ -262,14 +262,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -477,11 +477,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1004,24 +1004,24 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
 ]
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -1056,11 +1056,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- stop live-price polling from triggering multi-year market-data synchronization
- cache failed quote lookups for five minutes to prevent repeated provider calls
- update five vulnerable Python packages in the lock file
- add coverage for failed-quote caching

## Verification
- `uv run ruff check .`
- `uv run pytest -q` (42 passed)
- `uvx pip-audit -r <exported requirements>` (no known vulnerabilities)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm audit` (0 vulnerabilities)