### PR TITLE
Stop retaining BatesStocks CI build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,24 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "tests/**"
+      - "*.py"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "uv.lock"
   pull_request:
     branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -112,13 +124,6 @@ jobs:
 
       - name: Security audit
         run: npm audit --audit-level=high
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: frontend-build
-          path: frontend/build/
-          retention-days: 7
 
   docker-build:
     name: Docker build


### PR DESCRIPTION
## Summary
- stop uploading the unused frontend build bundle
- disable Docker build-record artifact uploads
- run main-branch CI only when image inputs change
- keep PR gates and layer caching unchanged

The frontend artifact had no downstream consumer. Docker documents `DOCKER_BUILD_RECORD_UPLOAD=false` as the switch for build-record artifacts. Path filters also prevent documentation or workflow-only merges from publishing an unchanged ARM64 image.

## Verification
- `git diff --check`
- existing CI workflow gates